### PR TITLE
fixed error where hit dice for level hp increase are rounded down

### DIFF
--- a/compendium/classes/barbarian.md
+++ b/compendium/classes/barbarian.md
@@ -69,7 +69,7 @@ aliases: ["Barbarian"]
 
 - **Hit Dice**: 1d12 per Barbarian level
 - **Hit Points at First Level:** 12 + CON
-- **Hit Points at Higher Levels:** add 6 OR 1d12 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 7 OR 1d12 + CON  (minimum of 1)
 
 ## Starting Barbarian
 

--- a/compendium/classes/bard.md
+++ b/compendium/classes/bard.md
@@ -69,7 +69,7 @@ aliases: ["Bard"]
 
 - **Hit Dice**: 1d8 per Bard level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Bard
 

--- a/compendium/classes/cleric.md
+++ b/compendium/classes/cleric.md
@@ -69,7 +69,7 @@ aliases: ["Cleric"]
 
 - **Hit Dice**: 1d8 per Cleric level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Cleric
 

--- a/compendium/classes/druid.md
+++ b/compendium/classes/druid.md
@@ -69,7 +69,7 @@ aliases: ["Druid"]
 
 - **Hit Dice**: 1d8 per Druid level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Druid
 

--- a/compendium/classes/fighter.md
+++ b/compendium/classes/fighter.md
@@ -42,7 +42,7 @@ aliases: ["Fighter"]
 
 - **Hit Dice**: 1d10 per Fighter level
 - **Hit Points at First Level:** 10 + CON
-- **Hit Points at Higher Levels:** add 5 OR 1d10 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 6 OR 1d10 + CON  (minimum of 1)
 
 ## Starting Fighter
 

--- a/compendium/classes/monk.md
+++ b/compendium/classes/monk.md
@@ -69,7 +69,7 @@ aliases: ["Monk"]
 
 - **Hit Dice**: 1d8 per Monk level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Monk
 

--- a/compendium/classes/paladin.md
+++ b/compendium/classes/paladin.md
@@ -69,7 +69,7 @@ aliases: ["Paladin"]
 
 - **Hit Dice**: 1d10 per Paladin level
 - **Hit Points at First Level:** 10 + CON
-- **Hit Points at Higher Levels:** add 5 OR 1d10 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 6 OR 1d10 + CON  (minimum of 1)
 
 ## Starting Paladin
 

--- a/compendium/classes/ranger.md
+++ b/compendium/classes/ranger.md
@@ -69,7 +69,7 @@ aliases: ["Ranger"]
 
 - **Hit Dice**: 1d10 per Ranger level
 - **Hit Points at First Level:** 10 + CON
-- **Hit Points at Higher Levels:** add 5 OR 1d10 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 6 OR 1d10 + CON  (minimum of 1)
 
 ## Starting Ranger
 

--- a/compendium/classes/rogue.md
+++ b/compendium/classes/rogue.md
@@ -69,7 +69,7 @@ aliases: ["Rogue"]
 
 - **Hit Dice**: 1d8 per Rogue level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Rogue
 

--- a/compendium/classes/sorcerer.md
+++ b/compendium/classes/sorcerer.md
@@ -69,7 +69,7 @@ aliases: ["Sorcerer"]
 
 - **Hit Dice**: 1d6 per Sorcerer level
 - **Hit Points at First Level:** 6 + CON
-- **Hit Points at Higher Levels:** add 3 OR 1d6 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 4 OR 1d6 + CON  (minimum of 1)
 
 ## Starting Sorcerer
 

--- a/compendium/classes/warlock.md
+++ b/compendium/classes/warlock.md
@@ -69,7 +69,7 @@ aliases: ["Warlock"]
 
 - **Hit Dice**: 1d8 per Warlock level
 - **Hit Points at First Level:** 8 + CON
-- **Hit Points at Higher Levels:** add 4 OR 1d8 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 5 OR 1d8 + CON  (minimum of 1)
 
 ## Starting Warlock
 

--- a/compendium/classes/wizard.md
+++ b/compendium/classes/wizard.md
@@ -69,7 +69,7 @@ aliases: ["Wizard"]
 
 - **Hit Dice**: 1d6 per Wizard level
 - **Hit Points at First Level:** 6 + CON
-- **Hit Points at Higher Levels:** add 3 OR 1d6 + CON  (minimum of 1)
+- **Hit Points at Higher Levels:** add 4 OR 1d6 + CON  (minimum of 1)
 
 ## Starting Wizard
 


### PR DESCRIPTION
The classes in the compendium show average hp increase that are the dice round down, which is not what the PHB provided. HP increase is rounded up.

Made the correction to all Hit Points sections in the `classes` folder